### PR TITLE
Complete port to manifest v3

### DIFF
--- a/background.js
+++ b/background.js
@@ -6,26 +6,6 @@ let bangs = [];
   bangs = await res.json();
 })();
 
-chrome.webRequest.onBeforeRequest.addListener(({ url }) => {
-  // Get search query from URL
-  const urlObj = new URL(url);
-  const query = urlObj.searchParams.get('q');
-
-  // Check if searching for a bang
-  if (query && query.startsWith('!')) {
-    // Redirect to DuckDuckGo
-    return {
-      redirectUrl: `https://www.duckduckgo.com/?q=${encodeURIComponent(query)}`,
-    };
-  }
-}, {
-  urls: [
-    "http://www.google.com/search*", "http://www.google.co.jp/search*", "http://www.google.co.uk/search*", "http://www.google.es/search*", "http://www.google.ca/search*", "http://www.google.de/search*", "http://www.google.it/search*", "http://www.google.fr/search*", "http://www.google.com.au/search*", "http://www.google.com.tw/search*", "http://www.google.nl/search*", "http://www.google.com.br/search*", "http://www.google.com.tr/search*", "http://www.google.be/search*", "http://www.google.com.gr/search*", "http://www.google.co.in/search*", "http://www.google.com.mx/search*", "http://www.google.dk/search*", "http://www.google.com.ar/search*", "http://www.google.ch/search*", "http://www.google.cl/search*", "http://www.google.at/search*", "http://www.google.co.kr/search*", "http://www.google.ie/search*", "http://www.google.com.co/search*", "http://www.google.pl/search*", "http://www.google.pt/search*", "http://www.google.com.pk/search*", "https://www.google.com/search*", "https://www.google.co.jp/search*", "https://www.google.co.uk/search*", "https://www.google.es/search*", "https://www.google.ca/search*", "https://www.google.de/search*", "https://www.google.it/search*", "https://www.google.fr/search*", "https://www.google.com.au/search*", "https://www.google.com.tw/search*", "https://www.google.nl/search*", "https://www.google.com.br/search*", "https://www.google.com.tr/search*", "https://www.google.be/search*", "https://www.google.com.gr/search*", "https://www.google.co.in/search*", "https://www.google.com.mx/search*", "https://www.google.dk/search*", "https://www.google.com.ar/search*", "https://www.google.ch/search*", "https://www.google.cl/search*", "https://www.google.at/search*", "https://www.google.co.kr/search*", "https://www.google.ie/search*", "https://www.google.com.co/search*", "https://www.google.pl/search*", "https://www.google.pt/search*", "https://www.google.com.pk/search*"
-  ],
-}, [
-  "blocking" // Needed so we can redirect the request to DuckDuckGo - we aren't really blocking anything
-]);
-
 // Omnibox Auto-Complete
 chrome.omnibox.onInputChanged.addListener((text, addSuggestions) => {
   let filterText = text.trim();

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Bangs for Google",
-  "version": "1.1",
+  "version": "1.2",
 
   "icons": {
     "32": "icons/icon-32.png",
@@ -12,17 +12,13 @@
   "description": "Use DuckDuckGo Bangs in the Google Search",
   "homepage_url": "https://github.com/vantezzen/bangs-for-google",
 
-  "permissions": [
-    "webRequest",
-    "webRequestBlocking",
+  "host_permissions": [
     "https://duckduckgo.com/bang.js",
     "http://www.google.com/search*", "http://www.google.co.jp/search*", "http://www.google.co.uk/search*", "http://www.google.es/search*", "http://www.google.ca/search*", "http://www.google.de/search*", "http://www.google.it/search*", "http://www.google.fr/search*", "http://www.google.com.au/search*", "http://www.google.com.tw/search*", "http://www.google.nl/search*", "http://www.google.com.br/search*", "http://www.google.com.tr/search*", "http://www.google.be/search*", "http://www.google.com.gr/search*", "http://www.google.co.in/search*", "http://www.google.com.mx/search*", "http://www.google.dk/search*", "http://www.google.com.ar/search*", "http://www.google.ch/search*", "http://www.google.cl/search*", "http://www.google.at/search*", "http://www.google.co.kr/search*", "http://www.google.ie/search*", "http://www.google.com.co/search*", "http://www.google.pl/search*", "http://www.google.pt/search*", "http://www.google.com.pk/search*", "https://www.google.com/search*", "https://www.google.co.jp/search*", "https://www.google.co.uk/search*", "https://www.google.es/search*", "https://www.google.ca/search*", "https://www.google.de/search*", "https://www.google.it/search*", "https://www.google.fr/search*", "https://www.google.com.au/search*", "https://www.google.com.tw/search*", "https://www.google.nl/search*", "https://www.google.com.br/search*", "https://www.google.com.tr/search*", "https://www.google.be/search*", "https://www.google.com.gr/search*", "https://www.google.co.in/search*", "https://www.google.com.mx/search*", "https://www.google.dk/search*", "https://www.google.com.ar/search*", "https://www.google.ch/search*", "https://www.google.cl/search*", "https://www.google.at/search*", "https://www.google.co.kr/search*", "https://www.google.ie/search*", "https://www.google.com.co/search*", "https://www.google.pl/search*", "https://www.google.pt/search*", "https://www.google.com.pk/search*"
   ],
 
   "background": {
-    "scripts": [
-      "background.js"
-    ]
+    "service_worker": "background.js"
   },
 
   "omnibox": {


### PR DESCRIPTION
All files have been updated to comply with the new manifest version 3.
Because _chrome.webRequest.onBeforeRequest_ is not available anymore, it has been completely removed.
Otherwise there were some small changes to the manifest.json so that it represents a vaild v3 format.